### PR TITLE
Fix missing parameter in process_records() in health check lambda

### DIFF
--- a/lambda_health_check.py
+++ b/lambda_health_check.py
@@ -119,7 +119,7 @@ def process_records(response, ecs_data):
                 HostedZoneId=hostedZoneId,
                 StartRecordName=response['NextRecordName'],
                 StartRecordType=response['NextRecordType'])
-        process_records(new_response)
+        process_records(new_response, ecs_data)
 
 def get_definition_for_container(name, containerDefinitions):
     for containerDefinition in containerDefinitions:


### PR DESCRIPTION
Fixes `process_records() missing 1 required positional argument: 'ecs_data': TypeError'`