### PR TITLE
Fix for SRV records with the standard naming scheme

### DIFF
--- a/lambda_health_check.py
+++ b/lambda_health_check.py
@@ -83,7 +83,7 @@ def process_records(response, ecs_data):
             for rr in record['ResourceRecords']:
                 [ip, port] = get_ip_port(rr)
                 if ip != None:
-                    task=search_ecs_task(ip, port, record['Name'].split('.')[0], ecs_data)
+                    task=search_ecs_task(ip, port, '.'.join(record['Name'].split('.')[0:2]), ecs_data)
                     if task == None:
                         delete_route53_record(record)
                         print("Record %s deleted" % rr)


### PR DESCRIPTION
Currently, the health check lambda gets the service name by parsing the resource record up to the first dot. As the usual naming scheme is `_service._protocol.domain`, e.g. `_xmpp-server._tcp.google.com`, the function would search for just `_xmpp-server` which is then not found in the container list.
This PR just changes the service name to include the first two components. It should probably be made a bit more resilient.

Here's the Wikipedia link to the record format: https://en.wikipedia.org/wiki/SRV_record