### PR TITLE
added docker based build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+ecssd_agent

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM scratch
+COPY  ecssd_agent /
+ENTRYPOINT ["/ecssd_agent"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+all:
+	docker run -e  \
+		GOPATH=/app/ \
+		--rm  \
+		-v "$(PWD):/target" \
+		-v "$(PWD):/app/src/github.com/awslabs/service-discovery-ecs-dns"  \
+		-w /target  \
+		golang:1.8 \
+		go build \
+		-o ecssd_agent \
+ 		-ldflags "-linkmode external -extldflags -static" \
+		github.com/awslabs/service-discovery-ecs-dns
+	 docker build -t awslabs/ecssd_agent:latest .


### PR DESCRIPTION
- Makefile file  to build a  Linux/amd64 executable on any platform.
- Dockerfile to create a Docker image awslab/ecssd_agent:latest.