### PR TITLE
Automatic A record management and custom hostnames

### DIFF
--- a/ecssd_agent.go
+++ b/ecssd_agent.go
@@ -188,7 +188,7 @@ func createARecord(hostName string, localIP string) error {
 					ResourceRecordSet: &route53.ResourceRecordSet{
 						Name: aws.String(aRecordName),
 						// It creates an A record with the IP of the host running the agent
-						Type: aws.String(route53.RRTypeA,
+						Type: aws.String(route53.RRTypeA),
 						ResourceRecords: []*route53.ResourceRecord{
 							{
 								// priority: the priority of the target host, lower value means more preferred
@@ -384,7 +384,6 @@ func main() {
 	var err error
 	var sum int
 	var zoneId string
-	var localIP string
 
 	var sendEvents = flag.Bool("cw-send-events", false, "Send CloudWatch events when a container is created or terminated")
 	
@@ -409,15 +408,14 @@ func main() {
 	}
 	configuration.HostedZoneId = zoneId
 	metadataClient := ec2metadata.New(session.New())
-	hostname, err := metadataClient.GetMetadata("/hostname")
-	configuration.Hostname = hostname
-	localIP = metadataClient.GetMetadata("/local-ipv4")
+	localIP, err := metadataClient.GetMetadata("/local-ipv4")
+	configuration.Hostname = "IP-" + strings.Replace(localIP, ".", "-", 3) + "." + DNSName
 	logErrorAndFail(err)
 	region, err := metadataClient.Region()
 	configuration.Region = region
 	logErrorAndFail(err)
 
-	if err = createARecord(hostName string, localIP string); err != nil {
+	if err = createARecord(configuration.Hostname, localIP); err != nil {
 		log.Error("Error creating host A record")
 	}
 

--- a/ecssd_agent.go
+++ b/ecssd_agent.go
@@ -409,7 +409,7 @@ func main() {
 	configuration.HostedZoneId = zoneId
 	metadataClient := ec2metadata.New(session.New())
 	localIP, err := metadataClient.GetMetadata("/local-ipv4")
-	configuration.Hostname = "IP-" + strings.Replace(localIP, ".", "-", 3) + "." + DNSName
+	configuration.Hostname = "ip-" + strings.Replace(localIP, ".", "-", 3) + "." + DNSName
 	logErrorAndFail(err)
 	region, err := metadataClient.Region()
 	configuration.Region = region

--- a/lambda_health_check.py
+++ b/lambda_health_check.py
@@ -109,9 +109,9 @@ def process_records(response, ecs_data):
         
         elif record['Type'] == 'A':
             for rr in record['ResourceRecords']:
-                if ecs_data['clusterPrivateIPs'].count(rr['Value']) == 0:
+                if (ecs_data['clusterPrivateIPs'].count(rr['Value']) == 0) and (record['Name'] == ('ip-' + rr['Value'].replace('.', '-') + '.' + domain + '.')):
                     delete_route53_record(record, 'Instance no longer exists in cluster')
-                    print("Record %s deleted" % rr)
+                    print("Record %s deleted" % rr['Value'])
                     break
 
                 elif ecs_data['clusterPrivateIPs'].count(rr['Value']) > 1:


### PR DESCRIPTION
The modifications I made are primarily designed to deal with issues of a custom instance hostname. 

Currently when an AMI with a custom hostname is used, the srv records created will point to that hostname but no A records exist automatically.

My modifications to the agent, automatically create A records for each ECS cluster instance and point the srv records to those A records. For example, you have an ECS cluster with an instance that has a private IP of 10.20.30.40. This cluster is running the ecssd_agent, a service named "time", and passed the agent the domain "example.com". The following srv and A records would be created.

- ip-10-20-30-40.example.com. | A | 10.20.30.40
- time.example.com. | SRV | 1 1 32769 ip-10-20-30-40.example.com.

I also updated the lambda health check function to automatically remove stale A records if they meet all the following criteria.
- The IP address associated with the A record is not currently in the ECS cluster.
- The record is formatted as ip-10-10-10-10.domain.tld. (where "10-10-10-10" is replaced with the octets of the IP address it points to, and "domain.tld" is the domain specified when starting the agent.)
