### PR TITLE
preference to use the first private zone in the case of the client us…

### DIFF
--- a/lambda_health_check.py
+++ b/lambda_health_check.py
@@ -29,7 +29,13 @@ ec2 = boto3.client('ec2')
 response = route53.list_hosted_zones_by_name(DNSName=domain)
 if len(response['HostedZones']) == 0:
     raise Exception('Zone not found')
-hostedZoneId = response['HostedZones'][0]['Id']
+
+for zone in response['HostedZones']:
+    if zone['Config']['PrivateZone']:
+        hostedZoneId = zone['Id']
+
+if not hostedZoneId:
+    hostedZoneId = response['HostedZones'][0]['Id']
 
 def get_ip_port(rr):
     try:


### PR DESCRIPTION
…ing the same domain for private and public zones

- In some cases the users are using the same domain name in private and public zones, then in that case we need to catch the zone id of the private zone instead of the public.

and try catch using this:
```
hostedZoneId = response['HostedZones'][0]['Id']
```
not assures that the private zone will be used

ex.
```
In [7]: for i in response['HostedZones']:
   ...:     print(i)
   ...:
{'ResourceRecordSetCount': 226, 'Name': 'company.com.br.', 'CallerReference': '289B8E08-3A2D-FA31-BCC3-063760414BDE', 'Config': {'**PrivateZone': False**, 'Comment': 'Company Production Zone'}, 'Id': '/hostedzone/Z32321223'}
{'ResourceRecordSetCount': 211, 'Name': 'company.com.br.', 'CallerReference': 'BF17B85C-61E1-21D3-A8D2-B7FB84B07A69', 'Config': {'PrivateZone': True, 'Comment': 'Internal Company Zone'}, 'Id': '/hostedzone/Z31238912E6'}
```
